### PR TITLE
tweaks to where the ip addresses are coming from

### DIFF
--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -1,5 +1,5 @@
 127.0.0.1 localhost
-127.0.1.1 {{ ansible_hostname }}
+#127.0.1.1 {{ ansible_hostname }}
 
 # The following lines are desirable for IPv6 capable hosts
 ::1 ip6-localhost ip6-loopback
@@ -9,7 +9,10 @@ ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 ff02::3 ip6-allhosts
 
-# mesh network hosts
-{% for entry in hosts_definitions %}
-{{ entry }}
+# START hostvars
+{% for item in groups['all'] %}
+{% if hostvars[ item ].ip_address is defined %}
+{{ hostvars[ item ].ip_address }} {{ item }} {{ hostvars[ item ].server_fqdn }}
+{% endif %}
 {% endfor %}
+# END hostvars


### PR DESCRIPTION
Using `groups['all']` now to add in addresses, and to use ip_address if it is specifically listed.