### PR TITLE
chore: cleanup for lint

### DIFF
--- a/tasks/hosts.local.yml
+++ b/tasks/hosts.local.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Register Date
   command: date
   connection: local
@@ -23,6 +22,5 @@
   lineinfile:
     dest: /etc/hosts
     regexp: '^127\.0\.0\.1'
-    line: '127.0.0.1 localhost'
-    # line: '127.0.0.1 localhost {{ inventory_hostname }} {{ server_fqdn }}'
+    line: "127.0.0.1 localhost"
   become: true

--- a/tasks/hosts.remote.yml
+++ b/tasks/hosts.remote.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Register Date
   command: date
   register: date_cmd
@@ -20,7 +19,7 @@
   lineinfile:
     dest: /etc/hosts
     regexp: '^127\.0\.0\.1'
-    line: '127.0.0.1 localhost {{ inventory_hostname }} {{ server_fqdn }}'
+    line: "127.0.0.1 localhost {{ inventory_hostname }} {{ server_fqdn }}"
     owner: root
     group: root
     mode: 0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,10 +5,10 @@
   when: inventory_hostname == 'localhost'
 
 - name: Set address list
-  set_fact: 
+  set_fact:
     address_list: "{{ hostvars[ item ].network.ip }} {{ item }} {{ hostvars[ item ].server_fqdn }}"
   with_items: "{{ groups.all }}"
-  when: 
+  when:
     - hostvars[ item ].network is defined
     - hostvars[ item ].network.ip is defined
     - (hostvars[ item ].include_in_hosts is undefined or hostvars[ item ].include_in_hosts)
@@ -16,7 +16,7 @@
   run_once: true
 
 - name: Create block list from address_list
-  set_fact: 
-    b1: "{{ r.results | selectattr('ansible_facts', 'defined') | selectattr('ansible_facts.address_list', 'defined')  | map(attribute='ansible_facts.address_list') | list }}"
+  set_fact:
+    b1: "{{ r.results | selectattr('ansible_facts', 'defined') | map(attribute='ansible_facts.address_list') | list }}"
 
 - include_tasks: hosts.{{ incl_type }}.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
   when: 
     - hostvars[ item ].network is defined
     - hostvars[ item ].network.ip is defined
-    - (hostvars[ item ].include_in_hosts is undefined or hostvars[ item ].include_in_hosts == true)
+    - (hostvars[ item ].include_in_hosts is undefined or hostvars[ item ].include_in_hosts)
   register: r
   run_once: true
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Chore

#### Changed behavior

Applied `ansible-lint` rules specifically to bump up scores on galaxy.


