### PR TITLE
chore: delegate to localhost

### DIFF
--- a/tasks/hosts.local.yml
+++ b/tasks/hosts.local.yml
@@ -1,7 +1,7 @@
 ---
 - name: Register Date
   command: date
-  connection: local
+  delegate_to: localhost
   register: date_cmd
 
 - name: Init block with date
@@ -9,7 +9,7 @@
     b1: "['# Updated at {{ date_cmd.stdout }}', ''] + {{ b1 }}"
 
 - name: Ensure the hosts block exists in /etc/hosts (local)
-  connection: local
+  delegate_to: localhost
   blockinfile:
     dest: /etc/hosts
     block: "{{ b1 | join('\n') }}"
@@ -18,7 +18,7 @@
   become: true
 
 - name: Ensure hostname is in /etc/hosts (local)
-  connection: local
+  delegate_to: localhost
   lineinfile:
     dest: /etc/hosts
     regexp: '^127\.0\.0\.1'

--- a/tasks/hosts.remote.yml
+++ b/tasks/hosts.remote.yml
@@ -19,7 +19,7 @@
   lineinfile:
     dest: /etc/hosts
     regexp: '^127\.0\.0\.1'
-    line: "127.0.0.1 localhost {{ inventory_hostname }} {{ server_fqdn }}"
+    line: "127.0.0.1 localhost {{ inventory_hostname }} {{ fqdn }}"
     owner: root
     group: root
     mode: 0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Set address list
   set_fact:
-    address_list: "{{ hostvars[ item ].network.ip }} {{ item }} {{ hostvars[ item ].server_fqdn }}"
+    address_list: "{{ hostvars[ item ].network.ip }} {{ item }} {{ hostvars[ item ].fqdn }}"
   with_items: "{{ groups.all }}"
   when:
     - hostvars[ item ].network is defined


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Chore

#### Changed behavior

Use `delegate_to: localhost` instead of `connection: local` due to `ansible` requirements.

#### Breaking Changes
* `server_fqdn` to `fqdn`